### PR TITLE
[고도화] 댓글 기능 고도화 - 1차 대댓글: 도메인 업데이트

### DIFF
--- a/src/main/java/com/fc/projectboard/domain/ArticleComment.java
+++ b/src/main/java/com/fc/projectboard/domain/ArticleComment.java
@@ -5,7 +5,9 @@ import lombok.Getter;
 import lombok.Setter;
 import lombok.ToString;
 
+import java.util.LinkedHashSet;
 import java.util.Objects;
+import java.util.Set;
 
 @Getter
 @ToString(callSuper = true)
@@ -27,6 +29,15 @@ public class ArticleComment extends AuditingFields {
     private UserAccount userAccount; // 유저 정보 (ID)
 
     @Setter
+    @Column(updatable = false)
+    private Long parentCommentId; // 부모 댓글 ID
+
+    @ToString.Exclude
+    @OrderBy("createdAt ASC")
+    @OneToMany(mappedBy = "parentCommentId", cascade = CascadeType.ALL)
+    private Set<ArticleComment> childComments = new LinkedHashSet<>();
+
+    @Setter
     @ManyToOne(optional = false)
     private Article article; // 게시글 (ID)
 
@@ -34,14 +45,20 @@ public class ArticleComment extends AuditingFields {
 
     protected ArticleComment() {}
 
-    private ArticleComment(Article article, UserAccount userAccount, String content) {
+    private ArticleComment(Article article, UserAccount userAccount, Long parentCommentId, String content) {
         this.article = article;
         this.userAccount = userAccount;
+        this.parentCommentId = parentCommentId;
         this.content = content;
     }
 
     public static ArticleComment of(Article article, UserAccount userAccount, String content) {
-        return new ArticleComment(article, userAccount, content);
+        return new ArticleComment(article, userAccount, null, content);
+    }
+
+    public void addChildComment(ArticleComment child) {
+        child.setParentCommentId(this.getId());
+        this.getChildComments().add(child);
     }
 
     @Override


### PR DESCRIPTION
`ArticleComment` 안에 부모댓글을 추가하였고, jpa 특성을 이용하여 자식 댓글들을 받아올 수 있도록 설정하였다.

단방향 연관관계로 설정.

1차 대댓글의 도메인 정보를 업데이트 하기 위한 PR : child-comments-domain -> child-comments

This closes #67 